### PR TITLE
no switch, lookup dictionary and chain-of-responsibility

### DIFF
--- a/AntiSwitch/AntiSwitch/Controller.cs
+++ b/AntiSwitch/AntiSwitch/Controller.cs
@@ -1,4 +1,7 @@
-﻿namespace AntiSwitch
+﻿using System.Collections.Generic;
+using System;
+
+namespace AntiSwitch
 {
     public class Controller
     {
@@ -28,6 +31,9 @@
 
     public interface IDomainLogic
     {
+        bool Handles(string scheme);
+        string Scheme { get; }
+
         string MetodoA(int param1, int param2);
         string MetodoB(int param1);
         string MetodoC(string param1, string param2);
@@ -35,10 +41,15 @@
 
     public class DomainLogicUomo
     {
-        public DomainLogicUomo(IDipendenzaA dipendenzaA, IDipendenzaB dipendenzaB)
+        string Scheme { get { return "u";} }
+        bool Handles(string scheme)
         {
-            
+            return scheme == "u" || 
+                   scheme == "uomo" || 
+                   DateTime.Now.Month == 11 ; // || qualsiasi altra logica
+                                              //    eventualmente usando dipendenze esterne
         }
+        public DomainLogicUomo(IDipendenzaA dipendenzaA, IDipendenzaB dipendenzaB) { }
     }
 
     public interface IDipendenzaA
@@ -53,32 +64,58 @@
 
     public class Smistatore
     {
-        readonly IDomainLogic _uomo;
-        readonly IDomainLogic _donna;
-        readonly IDomainLogic _bambino;
+        readonly Dictionary<string, IDomainLogic> _strategies;
 
         public Smistatore(IDomainLogic uomo, IDomainLogic donna, IDomainLogic bambino)
         {
-            _uomo = uomo;
-            _donna = donna;
-            _bambino = bambino;
+            _strategies = new Dictionary<string, IDomainLogic>{
+                {"u", uomo},
+                {"d", donna},
+                {"b", bambino}
+            };
         }
 
         public IDomainLogic Resolve(string scheme)
         {
-            switch(scheme)
-            {
-                case "u":
-                    return _uomo;
-                    break;
-                case "d":
-                    return _donna;
-                    break;
-                case "b":
-                    return _bambini;
-                    break;
-            }
+            return _strategies[scheme];
         }
     }
-}
 
+
+    public class AutoSmistatore
+    {
+        readonly Dictionary<string, IDomainLogic> _strategies;
+
+        public AutoSmistatore(List<IDomainLogic> strategies)
+        {
+            _strategies = new Dictionary<string, IDomainLogic>();
+            foreach(var strategy in strategies)
+            {
+                _strategies.Add(strategy.Scheme, strategy);
+            }
+        }
+
+        public IDomainLogic Resolve(string scheme)
+        {
+            return _strategies[scheme];
+        }
+    }
+
+    public class ChainOfResponsibility
+    {
+        readonly IEnumerable<IDomainLogic> _strategies;
+
+        public ChainOfResponsibility(List<IDomainLogic> strategies)
+        {
+            _strategies = strategies;
+        }
+
+        public IDomainLogic Resolve(string scheme)
+        {
+            foreach(var strategy in _strategies)
+            {
+                if (strategy.Handles(scheme))
+                    return strategy;
+            }}
+    }
+}

--- a/AntiSwitch/AntiSwitch/Controller.cs
+++ b/AntiSwitch/AntiSwitch/Controller.cs
@@ -28,7 +28,6 @@ namespace AntiSwitch
         }
     }
 
-
     public interface IDomainLogic
     {
         bool Handles(string scheme);
@@ -81,7 +80,6 @@ namespace AntiSwitch
         }
     }
 
-
     public class AutoSmistatore
     {
         readonly Dictionary<string, IDomainLogic> _strategies;
@@ -103,7 +101,7 @@ namespace AntiSwitch
 
     public class ChainOfResponsibility
     {
-        readonly IEnumerable<IDomainLogic> _strategies;
+        private readonly IEnumerable<IDomainLogic> _strategies;
 
         public ChainOfResponsibility(List<IDomainLogic> strategies)
         {
@@ -112,10 +110,24 @@ namespace AntiSwitch
 
         public IDomainLogic Resolve(string scheme)
         {
-            foreach(var strategy in _strategies)
+            foreach (var strategy in _strategies)
             {
                 if (strategy.Handles(scheme))
                     return strategy;
-            }}
+            }
+
+            throw new MissingHandlerException(string.Format("{0} scheme has no handler", scheme));
+        }
+    }
+
+    public class MissingHandlerException : Exception
+    {
+        public MissingHandlerException(Exception ex)
+            : base(ex.Message, ex)
+        { }
+
+        public MissingHandlerException(string message)
+            : base(message)
+        { }
     }
 }


### PR DESCRIPTION
Ciao @rrobuschi @granatac e @gcaferra.

Ho seguito il consiglio di Cristian, ed ho unito la mia soluzione con quella di Roberto, e poi vi ho incluso il suggerimento di Giuseppe di usare la Chain of Responsibility. Il risultato è in questa PR.

Mi sembra di capire che il problema che ci ha proposto Cristian si possa provare a risolvere decomponendolo in più problemi. Provo ad elencarli, magari voi vedete altri modi per decomporlo.

Si partiva da un codice così

```csharp
class Controller
{
   MetodoA(discriminante, altri_parametri...)
   {
       domain.MetodoA(discriminante, altri_parametri...);
   }
   MetodoB(discriminante, altri_parametri...)
   {
       domain.MetodoB(discriminante, altri_parametri...);
   }
}

class Domain
{
   MetodoA(discriminante, altri_parametri...)
   {
        switch(discriminante) {
           case 1:
               logica per caso 1
           case 2:
               logica per caso 2
   }
   MetodoB(discriminante, altri_parametri...)
   {
        switch(discriminante) {
           case 1:
               logica per caso 1
           case 2:
               logica per caso 2   }
}
```

I problemi da risolvere, in ordine di gravità, sono:

* la classe `Domain` è a conoscenza di tutti i casi (viola [Singe Responsibility Principle](https://en.wikipedia.org/wiki/Single_responsibility_principle))
* gli switch sono ripetuti (si viola [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself))
* c'è uno `switch`, e ormai ci siamo incaponiti che vogliamo eliminarlo, giusto? :smiling_imp: 

Partiamo dal primo problema. Per permettere a `Domain` di occuparsi di responsibility diverse vogliamo decomporlo in più classi, una per ogni caso. Quello che farei è spostare lo `switch` da `Domain` al `Controller`, cioè al piano sopra.

```csharp
class Controller
{
   MetodoA(discriminante, altri_parametri...)
   {
        switch(discriminante) {
           case 1:
               domainCaso1.MetodoA()
           case 2:
               domainCaso2.MetodoA()
   }
   MetodoB(discriminante, altri_parametri...)
   {
        switch(discriminante) {
           case 1:
               domainCaso1.MetodoB()
           case 2:
               domainCaso2.MetodoB()
   }
}

class Domain_Caso_1
{
   MetodoA(altri_parametri...)
   {
        logica per caso 1
   }
   MetodoB(altri_parametri...)
   {
        logica per caso 1
   }
}

class Domain_Caso_1
{
 .....
```

Il vantaggio è che abbiamo tante classi `Domain`, una per ogni caso (le classi sono più coese di prima).
Non abbiamo ridotto il numero di `switch`, ma almeno adesso rispettiamo la Singe Responsibility sulle classi `Domain`, che infatti non ricevono più `discriminante`: lo smistamento è avvenuto prima. 

Adesso proviamo ad eliminare la ripetizione degli `switch` e portarci ad un solo `switch` comune.
Per farlo, diamo un occhio a cosa fa ogni `switch`.

```csharp
        switch(discriminante) {
           case 1:
               domainCaso1.MetodoA()
           case 2:
               domainCaso2.MetodoA()
```

In effetti, ogni `switch` sta a sua volta violando il Single Responsibility Principle; fa due cose:

1. seleziona la classe `Domain` per il caso giusto
2. chiama il metodo giusto. 

Proviamo a spezzare lo `switch` in due, e cerchiamo di ottenere uno `switch` che abbia solo la responsabilità di fare la prima cosa, darci la classe `Domain` giusta. Si arriva alla soluzione che avevo proposto stamani, una classe `Risolutore` il cui compito è usare il valore di `discriminante` per restituire l'istanza di `Domain` corretta

```csharp
class Risolutore
{
   Risolvi(discriminante)
   {
       switch(discriminante) {
           case 1:
               return domainCaso1
           case 2:
               return domainCaso2
   }
}
```

Con il risolutore, gli `switch` scompaiono dal `Controller`:

```csharp
class Controller
{
   MetodoA(discriminante, altri_parametri...)
   {
        risolutore.risolvi(discriminante).MetodoA()
   }
   MetodoB(discriminante, altri_parametri...)
   {
        risolutore.risolvi(discriminante).MetodoB()
   }
}
```

Delle due responsabilità, abbiamo spostato la seconda (chiamare il metodo giusto) dallo `switch` al `Controller`, e questo ci ha permesso di eliminare la ripetizione degli `switch`.

Adesso non ci resta che risolvere il terzo problema, eliminare l'ultimo `switch` superstite.
Si può fare con un `Dictionary`, o una tupla, come suggerisce Roberto

```csharp
class Risolutore
    {
        Dictionary<string, IDomain> _domains;

        public Risolutore(IDomain domain1, IDomain domain2)
        {
            _domains = new Dictionary<string, IDomainLogic>{
                {"caso1", domain1},
                {"caso2", domain2},
            };
        }

        public risolvi(discriminante)
        {
            return _domains[discriminante];
        }
    }
```

Ma possiamo fare di più. Possiamo fare in modo che ogni dominio sappia quale discriminante è capace di gestire. Invece di avere `"caso1"` e `"caso2"` dentro `Risolutore`, `Risolutore` chiede ad ogni `Domain` quale sia il discriminante che sa gestire

```csharp
class Risolutore
    {
        Dictionary<string, IDomain> _domains;

        public Risolutore(List<IDomain> domains)
        {
            _domains = new Dictionary<string, IDomainLogic>()
             foreach(domain in domains) {
                _domains.Add{domain.DiscriminanteGestita, domain)
        }

        public risolvi(discriminante)
        {
            return _domains[discriminante];
        }
    }
```

Il vantaggio è che adesso aggiungere un nuovo `Domain` per la gestione di un nuovo `discriminante` è semplice e richiede il cambio di codice in un solo punto: basta creare la nuova classe, impostarla su un nuovo `discriminante` e aggiungerne un'istanza a runtime al `Risolutore`. Non c'è più bisogno di cambiare il codice di `Risolutore`: è diventato più dinamico.
Ovviamente dobbiamo aggiungere una `discriminanteGestita` in ogni `Domain`, per esempio

```csharp
class Domain_Caso_1
{
   DiscriminanteGestita = "1"

   MetodoA(altri_parametri...)
   {
        logica per caso 1
   }
   MetodoB(altri_parametri...)
   {
        logica per caso 1
   }
}

```


Da qui a seguire il suggerimento di Giuseppe è un attimo: perché non passare direttamente il discriminante alle classi `Domain`, cosi `Smistatore`, che ha un elenco di tutti i `Domain`, quando riceve un `discriminante` chiede ad ogni `Domain`, uno dopo l'altro "Tu sai gestire questo `discriminante`?". Se la risposta è no, lo `Smistatore` chiede al successivo `Domain` in cerca di quello che ha la responsabilità su quel `discriminante` (da qui [Chain of Responsibility](https://en.wikipedia.org/wiki/Chain-of-responsibility_pattern)).
Con questa tecnica, ogni `Domain` è libero di implementare una logica qualsiasi per valutare se essere responsabile o meno di un `discriminante`: con un dictionary la logica possibile è solo un'associazione stringa => classe, ma con una Chain of Responsibility potete implementare quello che volete.

Il `Risolutore` diventa così

```csharp
class Risolutore
    {
        Dictionary<string, IDomain> _domains;

        public Risolutore(List<IDomain> domains)
        {
            _domains = domains
        }

        public risolvi(discriminante)
        {
            foreach(domain in _domains)
                if domain.IsResponsibleOf(discriminante)
                    return domain
            throw new Exception("discriminante non gestita")
        }
    }
```

```csharp
class Domain_Caso_1
{
   bool IsResponsibleOf(discriminante) {
          logica qualsiasi
   } 

   MetodoA(altri_parametri...)
   {
        logica per caso 1
   }
   MetodoB(altri_parametri...)
   {
        logica per caso 1
   }
}
```


Ma a pensarci bene, così abbiamo reintrodotto un `if` dento un ciclo, quindi uno `switch` :expressionless: 